### PR TITLE
No more decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,16 @@ myCoolState.foo.bar = "bamf";
 
 ## How can it do this?
 
-When isn't magic, it will try to detect different kinds of observable objects and subscribe to them, but you will probably have to make your main object a subclass of the `Model` class. This class doesn't do much other than allow you to provide an annotation `@notify` to describe properties that should notify when you change them.
+When isn't magic, it will try to detect different kinds of observable objects and subscribe to them, but you will probably have to make your main object a subclass of the `Model` class. This class doesn't do much other than allow you to provide a list of properties that should notify when you change them.
 
 ```js
-@notify('toastCount')
 class Toaster : Model {
   toastCount: int;
   brandName: string;
+
+  constructor() {
+    this.propertyShouldNotify('toastCount');
+  }
 }
 
 // Observing properties with @notify == works!

--- a/packages/when/src/__tests__/model.ts
+++ b/packages/when/src/__tests__/model.ts
@@ -7,7 +7,7 @@ import { TestClass } from './support';
 
 import { createCollection } from '../custom-operators';
 
-describe('the notify attribute', function() {
+describe('the notify method', function() {
   it('should notify me!', function() {
     const fixture = new TestClass();
 

--- a/packages/when/src/__tests__/model.ts
+++ b/packages/when/src/__tests__/model.ts
@@ -1,5 +1,7 @@
-import { merge } from 'rxjs';
+import { merge, of } from 'rxjs';
 import { map } from 'rxjs/operators';
+
+import { Model } from '../model';
 
 import { TestClass } from './support';
 
@@ -37,11 +39,26 @@ describe('the notify attribute', function() {
   });
 });
 
+export class ToPropertyTwiceIsBad extends Model {
+  derived: number;
+
+  constructor() {
+    super();
+
+    this.toProperty(of(5), 'derived');
+    this.toProperty(of(42), 'derived');
+  }
+}
+
 describe('the toProperty method', function() {
   it('should return a canned value', function() {
     const fixture = new TestClass();
 
     expect(fixture.derived).toBe(42);
+  });
+
+  it('should blow up if you try to toProperty twice', function() {
+    expect(() => new ToPropertyTwiceIsBad()).toThrowError();
   });
 
   it('should notify on changes', function() {

--- a/packages/when/src/__tests__/model.ts
+++ b/packages/when/src/__tests__/model.ts
@@ -7,7 +7,7 @@ import { TestClass } from './support';
 
 import { createCollection } from '../custom-operators';
 
-describe('the notify method', function() {
+describe('the propertyShouldNotify method', function() {
   it('should notify me!', function() {
     const fixture = new TestClass();
 

--- a/packages/when/src/__tests__/support.ts
+++ b/packages/when/src/__tests__/support.ts
@@ -25,7 +25,7 @@ export class TestClass extends Model {
     this.updatableFoo = new Updatable(() => of(6));
     this.someSubject = new Subject();
 
-    this.notify('foo', 'bar', 'arrayFoo');
+    this.propertyShouldNotify('foo', 'bar', 'arrayFoo');
 
     this.toProperty(of(42), 'derived');
 

--- a/packages/when/src/__tests__/support.ts
+++ b/packages/when/src/__tests__/support.ts
@@ -1,10 +1,9 @@
 import { of, Subject } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
-import { Model, notify } from '../model';
+import { Model } from '../model';
 import { Updatable } from '../updatable';
 
-@notify('foo', 'bar', 'arrayFoo')
 export class TestClass extends Model {
   someSubject: Subject<number>;
   foo: number;
@@ -25,6 +24,8 @@ export class TestClass extends Model {
     this.arrayFoo = [1];
     this.updatableFoo = new Updatable(() => of(6));
     this.someSubject = new Subject();
+
+    this.notify('foo', 'bar', 'arrayFoo');
 
     this.toProperty(of(42), 'derived');
 

--- a/packages/when/src/__tests__/support.ts
+++ b/packages/when/src/__tests__/support.ts
@@ -1,7 +1,7 @@
 import { of, Subject } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
-import { fromObservable, Model, notify } from '../model';
+import { Model, notify } from '../model';
 import { Updatable } from '../updatable';
 
 @notify('foo', 'bar', 'arrayFoo')
@@ -12,8 +12,9 @@ export class TestClass extends Model {
   baz: number;
   arrayFoo: number[];
   updatableFoo: Updatable<number>;
-  @fromObservable derived: number;
-  @fromObservable subjectDerived: number;
+
+  derived: number;
+  subjectDerived: number;
 
   get explodingProperty(): TestClass {
     throw new Error('Kaplowie');

--- a/packages/when/src/index.ts
+++ b/packages/when/src/index.ts
@@ -1,5 +1,5 @@
 // export { Action } from './action';
 export { createCollection } from './custom-operators';
-export { ChangeNotification, TypedChangeNotification, Model, notify } from './model';
+export { ChangeNotification, TypedChangeNotification, Model } from './model';
 export { MergeStrategy, Updatable } from './updatable';
 export { getValue, when, whenProperty } from './when';

--- a/packages/when/src/index.ts
+++ b/packages/when/src/index.ts
@@ -1,5 +1,5 @@
 // export { Action } from './action';
 export { createCollection } from './custom-operators';
-export { ChangeNotification, TypedChangeNotification, Model, notify, fromObservable } from './model';
+export { ChangeNotification, TypedChangeNotification, Model, notify } from './model';
 export { MergeStrategy, Updatable } from './updatable';
 export { getValue, when, whenProperty } from './when';

--- a/packages/when/src/model.ts
+++ b/packages/when/src/model.ts
@@ -31,9 +31,12 @@ export class Model {
 
   toProperty<T>(input: Observable<T>, propertyKey: string) {
     const obsPropertyKey: string = `___${propertyKey}_Observable`;
-    if (!(obsPropertyKey in this)) {
-      throw new Error(`Make sure to mark ${propertyKey} with the @fromObservable decorator`);
+
+    if (obsPropertyKey in this) {
+      throw new Error("Calling toProperty twice on the same property isn't supported");
     }
+
+    enablePropertyAsObservable(this, propertyKey);
 
     this[obsPropertyKey] = input;
     // tslint:disable-next-line:no-unused-expression
@@ -92,13 +95,14 @@ export function notify(...properties: Array<string>) {
   };
 }
 
-export function fromObservable(target: Model, propertyKey: string): void {
-  if (propertyKey in target) delete target[propertyKey];
-
+function enablePropertyAsObservable(target: Model, propertyKey: string): void {
   const obsPropertyKey: string = `___${propertyKey}_Observable`;
   const valPropertyKey: string = `___${propertyKey}_Latest`;
   const subPropertyKey: string = `___${propertyKey}_Subscription`;
 
+  if (obsPropertyKey in target) { return; }
+
+  if (propertyKey in target) delete target[propertyKey];
   target[obsPropertyKey] = null;
 
   Object.defineProperty(target, propertyKey, {

--- a/packages/when/src/model.ts
+++ b/packages/when/src/model.ts
@@ -29,7 +29,7 @@ export class Model {
     this.innerDisp = new Subscription();
   }
 
-  notify(...properties: Array<string>) {
+  propertyShouldNotify(...properties: Array<string>) {
     const proto = Object.getPrototypeOf(this);
     if (proto.__notifySetUp__) {
       return;


### PR DESCRIPTION
Decorator syntax is too hard to support with Babel 7 now (i.e. if you use TypeScript compilation, you get legacy decorators, and if you use `@babel/preset-typescript`, you get current-spec decorators). Instead, get rid of `fromObservable` entirely, and move `@notify` to a regular method `propertyShouldNotify`. Later, we'll make this type-safe, but for now just use strings